### PR TITLE
Prevent survey question from repeating itself when ? is entered for help

### DIFF
--- a/cmd/node.go
+++ b/cmd/node.go
@@ -201,10 +201,10 @@ func qInterfaces() *survey.Question {
 		Name: "interfaces",
 		Prompt: &survey.MultiSelect{
 			Message: "Choose your capture interface(s):",
-			Help: `The interfaces you most likely want to use for capturing start 
-		with "eth" or "en" (e.g. eth0, eno1, enp1s0, enx78e7d1ea46da). You will generally NOT 
-		want to use loopback, bridged, or virtual interfaces (e.g. lo, br-c446eb08dde, veth582437d).
-		If you choose to select interfaces belonging to the latter category, proceed at your own risk.`,
+			Help: `The interfaces you most likely want to use for capturing start
+with "eth" or "en" (e.g. eth0, eno1, enp1s0, enx78e7d1ea46da). You will generally NOT
+want to use loopback, bridged, or virtual interfaces (e.g. lo, br-c446eb08dde, veth582437d).
+If you choose to select interfaces belonging to the latter category, proceed at your own risk.`,
 			Options:  displayNames,
 			Default:  suggestedNames,
 			PageSize: 20,
@@ -229,8 +229,8 @@ func qProcesses() *survey.Question {
 		Prompt: &survey.Input{
 			Message: "How many total Zeek processes do you want?",
 			Help: `You will generally get the best performance by making your total number of Zeek processes
-	one less than the number of CPU cores your system has. If your system is used for something
-	in addition to Zeek you may want to reduce the number of processes further.`,
+one less than the number of CPU cores your system has. If your system is used for something
+in addition to Zeek you may want to reduce the number of processes further.`,
 			Default: strconv.Itoa(int(suggestedProcesses())),
 		},
 		// Only numbers up to how many cores there are
@@ -250,8 +250,8 @@ func qSocketType() *survey.Question {
 		Name: "socketType",
 		Prompt: &survey.Select{
 			Message: "What type of network socket do you want to use?",
-			Help: `Choosing the afpacket option here can improve performance. However, you must have 
-    the corresponding zeek plugin to use it.`,
+			Help: `Choosing the afpacket option here can improve performance. However, you must have
+the corresponding zeek plugin to use it.`,
 			Options: []string{sockRaw, sockAfpacket},
 			Default: sockRaw,
 		},

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 )
 
-replace github.com/AlecAivazis/survey/v2 => github.com/Zalgo2462/survey/v2 v2.0.8-0.20200624020207-2d2e06c55d31
+replace github.com/AlecAivazis/survey/v2 => github.com/Zalgo2462/survey/v2 v2.0.8-0.20200625180604-93e08bfe2dd3

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Zalgo2462/survey/v2 v2.0.8-0.20200624020207-2d2e06c55d31 h1:pLBCGnkuRkjvcRR2GzhF2YDzuBdU8y38Qxee0mT+94w=
 github.com/Zalgo2462/survey/v2 v2.0.8-0.20200624020207-2d2e06c55d31/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
+github.com/Zalgo2462/survey/v2 v2.0.8-0.20200625180604-93e08bfe2dd3 h1:6hO/HmknGRCSlv3wNET8VCKbf9uVi5cNJdsdOjkCTDg=
+github.com/Zalgo2462/survey/v2 v2.0.8-0.20200625180604-93e08bfe2dd3/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
Removes tabs from the help messages to allow the word wrap calculation to succeed in survey. This prevents corrupting the survey question output when ? is pressed. Related: https://github.com/AlecAivazis/survey/pull/291#issuecomment-649918115

Also, updated survey code to allow for reszing the window. 

I assume a release and pr will need to be made to integrate these changes with docker-zeek?